### PR TITLE
Fix crash due to % conversion patterns

### DIFF
--- a/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
+++ b/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
@@ -89,7 +89,8 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
 
             // add a message id field if any is defined for this logging event
             if (mdc.containsKey(SystemdJournal.MESSAGE_ID)) {
-                messages.add("MESSAGE_ID=" + mdc.get(SystemdJournal.MESSAGE_ID));
+                messages.add("MESSAGE_ID=%s");
+                messages.add(mdc.get(SystemdJournal.MESSAGE_ID));
             }
             // the vararg list is null terminated
             messages.add(null);

--- a/src/test/java/org/gnieh/logback/TestPercentEscaping.java
+++ b/src/test/java/org/gnieh/logback/TestPercentEscaping.java
@@ -1,0 +1,26 @@
+package org.gnieh.logback;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+
+public class TestPercentEscaping {
+
+    static Logger logger = LoggerFactory.getLogger(TestPercentEscaping.class);
+
+    public static void main(String[] args) {
+        MDC.put(SystemdJournal.MESSAGE_ID, "we get away with %s, since it uses the null terminator arg");
+        logger.info("fine");
+        MDC.put(SystemdJournal.MESSAGE_ID, "we get away with %i as well, and it converts to 0");
+        logger.info("fine");
+
+        // Everything below will crash unless % is escaped (% -> %%)
+        
+        MDC.put(SystemdJournal.MESSAGE_ID, "this %s %s crashes since there's no 2nd subsequent arg");
+        logger.info("boom");
+        
+        MDC.put(SystemdJournal.MESSAGE_ID, "this %1$ causes the JVM to abort");
+        logger.info("boom");
+    }
+
+}


### PR DESCRIPTION
We use a slightly modified version of `logback-journal`, where we include all MDC as metadata fields.  We bumped into an issue where, if a value has a pattern like `%1$`, or simply more than one `%s` or `%i` style reference, it causes the JVM to crash.

The reason is because `vsprintf` was trying to resolve them against the subsequent arguments, and there was only one following arg -- the null terminator.

Included is a test with a couple of variants that easily reproduce the crash.

There are two ways to fix this:
1. Escape any `%` with `%%` so `vsprintf` doesn't trip up on it.
2. Avoid `vsprintf` looking at the value in the first place, by simply using `MESSAGE_ID=%s` and passing the value as a following argument.  That way it's treated as a literal value and not a format pattern.

The latter is easiest, and that's the fix I've gone with here.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gnieh/logback-journal/4)
<!-- Reviewable:end -->
