### PR TITLE
Make SYSLOG_IDENTIFIER configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,10 @@ Basic configuration to use the systemd journal appender looks like this:
 
 The appender can be configured with the following properties
 
-Property name   | Type    | Description | Default Value
---------------- | ------- | ----------- | -------------
-`logLocation`   | boolean | Determines whether the exception locations are logged when present. This data is logged in standard systemd journal fields `CODE_FILE`, `CODE_LINE` and `CODE_FUNC`. | `true`
-`logException`  | boolean | Determines whether the exception name and messages are logged. This data is logged in the user fields `EXN_NAME` and `EXN_MESSAGE`. | `true`
-`logThreadName` | boolean | Determines whether the thread name is logged. This data is logged in the user field `THREAD_NAME`. | `true`
+Property name      | Type    | Description | Default Value
+------------------ | ------- | ----------- | -------------
+`logLocation`      | boolean | Determines whether the exception locations are logged when present. This data is logged in standard systemd journal fields `CODE_FILE`, `CODE_LINE` and `CODE_FUNC`. | `true`
+`logException`     | boolean | Determines whether the exception name and messages are logged. This data is logged in the user fields `EXN_NAME` and `EXN_MESSAGE`. | `true`
+`logThreadName`    | boolean | Determines whether the thread name is logged. This data is logged in the user field `THREAD_NAME`. | `true`
+`syslogIdentifier` | String  | Overrides the syslog identifier string. This data is logged in the user field `SYSLOG_IDENTIFIER`. | The process name (i.e. "java")
 

--- a/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
+++ b/src/main/java/org/gnieh/logback/SystemdJournalAppender.java
@@ -26,9 +26,9 @@ import ch.qos.logback.core.AppenderBase;
 
 /**
  * An appender that send the events to systemd journal
- * 
+ *
  * @author Lucas Satabin
- * 
+ *
  */
 public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
 
@@ -37,6 +37,8 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
     boolean logException = true;
 
     boolean logThreadName = true;
+
+    String syslogIdentifier = "";
 
     @Override
     protected void append(ILoggingEvent event) {
@@ -92,6 +94,13 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
                 messages.add("MESSAGE_ID=%s");
                 messages.add(mdc.get(SystemdJournal.MESSAGE_ID));
             }
+
+            // override the syslog identifier string if set
+            if (!syslogIdentifier.isEmpty()) {
+                messages.add("SYSLOG_IDENTIFIER=%s");
+                messages.add(syslogIdentifier);
+            }
+
             // the vararg list is null terminated
             messages.add(null);
 
@@ -143,4 +152,11 @@ public class SystemdJournalAppender extends AppenderBase<ILoggingEvent> {
         this.logException = logException;
     }
 
+    public String getSyslogIdentifier() {
+        return syslogIdentifier;
+    }
+
+    public void setSyslogIdentifier(String syslogIdentifier) {
+        this.syslogIdentifier = syslogIdentifier;
+    }
 }


### PR DESCRIPTION
Not sure if it's just my version of systemd (208, opensuse 13.1), but if SYSLOG_IDENTIFIER isn't set then the process appears as "java" in the journal instead of the SyslogIdentifier configured in the service file. This change makes it so that you can explicitly set the SYSLOG_IDENTIFIER field.